### PR TITLE
Correct declaration of sensor_num

### DIFF
--- a/common/service/sensor/sensor.c
+++ b/common/service/sensor/sensor.c
@@ -269,22 +269,22 @@ __weak void pal_fix_sensor_config(void)
 	return;
 }
 
-bool stby_access(uint8_t sensor_number)
+bool stby_access(uint8_t sensor_num)
 {
 	return true;
 }
 
-bool dc_access(uint8_t sensor_number)
+bool dc_access(uint8_t sensor_num)
 {
 	return get_DC_on_delayed_status();
 }
 
-bool post_access(uint8_t sensor_number)
+bool post_access(uint8_t sensor_num)
 {
 	return get_post_status();
 }
 
-bool me_access(uint8_t sensor_number)
+bool me_access(uint8_t sensor_num)
 {
 	if (get_me_mode() == ME_NORMAL_MODE) {
 		return get_post_status();

--- a/meta-facebook/yv35-bb/src/platform/plat_sensor_table.c
+++ b/meta-facebook/yv35-bb/src/platform/plat_sensor_table.c
@@ -10,7 +10,7 @@
 #include "plat_def.h"
 
 #define CONFIG_ISL69260 false
-bool stby_access(uint8_t sensor_number);
+bool stby_access(uint8_t sensor_num);
 
 sensor_cfg plat_sensor_config[] = {
 	/* number,                  type,       port,      address,      offset,


### PR DESCRIPTION
The migration of sensor functions had some mistakes in the declaration. This causes the following error messages.
```
Errors Found:
common/service/sensor/sensor.c:274:26:Function 'stby_access' argument 1 names different: declaration 'sensor_num' definition 'sensor_number'.
common/service/sensor/sensor.c:279:24:Function 'dc_access' argument 1 names different: declaration 'sensor_num' definition 'sensor_number'.
common/service/sensor/sensor.c:284:26:Function 'post_access' argument 1 names different: declaration 'sensor_num' definition 'sensor_number'.
common/service/sensor/sensor.c:289:24:Function 'me_access' argument 1 names different: declaration 'sensor_num' definition 'sensor_number'.
```
Signed-off-by: Scron Chang <Scron.Chang@quantatw.com>