### PR TITLE
Wc mb add ina230

### DIFF
--- a/common/dev/ina230.c
+++ b/common/dev/ina230.c
@@ -1,15 +1,58 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "ina230.h"
 #include "sensor.h"
 #include "hal_i2c.h"
 
-static double cur_lsb = 0.0;
+#define I2C_RETRY 5
+
+#define INA230_BUS_VOLTAGE_LSB 0.00125 // 1.25 mV.
+#define INA230_VSH_VOLTAGE_LSB 0.0000025 // 2.5 uV.
+
+#define INA230_ALT_MASK 0xF800
+#define INA230_ALT_SOL_OFFSET 0x8000
+#define INA230_ALT_SUL_OFFSET 0x4000
+#define INA230_ALT_BOL_OFFSET 0x2000
+#define INA230_ALT_BUL_OFFSET 0x1000
+#define INA230_ALT_POL_OFFSET 0x0800
+
+uint8_t ina230_reset_alt(uint8_t sensor_num)
+{
+	I2C_MSG msg = { 0 };
+
+	sensor_cfg *cfg;
+	ina230_init_arg *init_args;
+
+	if (sensor_num > SENSOR_NUM_MAX) {
+		return SENSOR_UNSPECIFIED_ERROR;
+	}
+
+	init_args = (ina230_init_arg *)sensor_config[sensor_config_index_map[sensor_num]].init_args;
+	if (init_args->is_init == false) {
+		printf("[%s], device isn't initialized\n", __func__);
+		return SENSOR_UNSPECIFIED_ERROR;
+	}
+
+	cfg = &sensor_config[sensor_config_index_map[sensor_num]];
+
+	msg.bus = cfg->port;
+	msg.target_addr = cfg->target_addr;
+	msg.rx_len = 2;
+	msg.tx_len = 1;
+	msg.data[0] = INA230_MSK_OFFSET;
+
+	if (i2c_master_read(&msg, I2C_RETRY)) {
+		return SENSOR_FAIL_TO_ACCESS;
+	}
+
+	return SENSOR_READ_SUCCESS;
+}
 
 uint8_t ina230_read(uint8_t sensor_num, int *reading)
 {
 	double val = 0.0;
-	uint8_t retry = 5;
+	int16_t signed_reg_val = 0;
 	uint16_t reg_val = 0;
 	I2C_MSG msg = { 0 };
 
@@ -34,18 +77,21 @@ uint8_t ina230_read(uint8_t sensor_num, int *reading)
 	msg.rx_len = 2;
 	msg.data[0] = cfg->offset;
 
-	if (i2c_master_read(&msg, retry))
+	if (i2c_master_read(&msg, I2C_RETRY))
 		return SENSOR_FAIL_TO_ACCESS;
 
-	reg_val = (msg.data[1] << 8) | msg.data[0];
+	reg_val = (msg.data[0] << 8) | msg.data[1];
 
 	switch (cfg->offset) {
+	case INA230_BUS_VOL_OFFSET:
+		val = (double)(reg_val)*INA230_BUS_VOLTAGE_LSB;
+		break;
 	case INA230_PWR_OFFSET:
-		// The power LSB is internally programmed to equal 25 times the current LSB.
-		val = (double)(reg_val)*cur_lsb * 25.0;
+		val = (double)(reg_val)*init_args->pwr_lsb;
 		break;
 	case INA230_CUR_OFFSET:
-		val = (double)(reg_val)*cur_lsb;
+		signed_reg_val = (int16_t)reg_val;
+		val = (double)(signed_reg_val)*init_args->cur_lsb;
 		break;
 	default:
 		return SENSOR_NOT_FOUND;
@@ -59,8 +105,7 @@ uint8_t ina230_read(uint8_t sensor_num, int *reading)
 
 uint8_t ina230_init(uint8_t sensor_num)
 {
-	uint16_t calibration = 0;
-	uint8_t retry = 5;
+	uint16_t calibration = 0, alt_reg = 0;
 	I2C_MSG msg = { 0 };
 
 	ina230_init_arg *init_args;
@@ -86,38 +131,94 @@ uint8_t ina230_init(uint8_t sensor_num)
 	 * - r_shunt : Value of the shunt resistor.
 	 * Ref: https://www.ti.com/product/INA230
 	 */
-	cur_lsb = init_args->i_max / 32768.0;
-	calibration = (uint16_t)(0.00512 / (cur_lsb * init_args->r_shunt));
+	init_args->cur_lsb = init_args->i_max / 32768.0;
+	calibration = (uint16_t)(0.00512 / (init_args->cur_lsb * init_args->r_shunt));
+
+	// The power LSB is internally programmed to equal 25 times the current LSB.
+	init_args->pwr_lsb = init_args->cur_lsb * 25.0;
 
 	msg.bus = sensor_config[sensor_config_index_map[sensor_num]].port;
 	msg.target_addr = sensor_config[sensor_config_index_map[sensor_num]].target_addr;
 	msg.tx_len = 3;
 	msg.data[0] = INA230_CFG_OFFSET;
-	msg.data[1] = init_args->config.value & 0xFF;
-	msg.data[2] = (init_args->config.value >> 8) & 0xFF;
+	msg.data[1] = (init_args->config.value >> 8) & 0xFF;
+	msg.data[2] = init_args->config.value & 0xFF;
 
-	if (i2c_master_write(&msg, retry)) {
-		printf("<error> INA230 initial failed while i2c writing\n");
+	if (i2c_master_write(&msg, I2C_RETRY)) {
+		printf("Failed to set INA230(%.2d-%.2x) configuration.\n", msg.bus,
+		       msg.target_addr);
+		return SENSOR_INIT_UNSPECIFIED_ERROR;
+	}
+
+	// The size of calibration is 15 bits, and the MSB is unused.
+	if (calibration & 0x8000) {
+		printf("Failed to set INA230(%.2d-%.2x) calibration due to"
+		       " the data overflowed (CAL: 0x%.2X)\n",
+		       msg.bus, msg.target_addr, calibration);
 		return SENSOR_INIT_UNSPECIFIED_ERROR;
 	}
 
 	memset(msg.data, 0, I2C_BUFF_SIZE);
 	msg.data[0] = INA230_CAL_OFFSET;
+	msg.data[1] = (calibration >> 8) & 0xFF;
+	msg.data[2] = calibration & 0xFF;
 
-	if (calibration & 0x8000) {
-		// The size of calibration is 16 bits, and the MSB is unused.
-		printf("<warning> INA230 the calibration register overflowed (0x%.2X)\n",
-		       calibration);
-		calibration = calibration & 0x7FFF;
-	}
-
-	msg.data[1] = calibration & 0xFF;
-	msg.data[2] = (calibration >> 8) & 0xFF;
-
-	if (i2c_master_write(&msg, retry)) {
-		printf("<error> INA230 initial failed while i2c writing\n");
+	if (i2c_master_write(&msg, I2C_RETRY)) {
+		printf("Failed to set INA230(%.2d-%.2x) calibration.\n", msg.bus, msg.target_addr);
 		return SENSOR_INIT_UNSPECIFIED_ERROR;
 	}
+
+	if (init_args->alt_cfg.value & INA230_ALT_MASK) {
+		if (init_args->alert_value == 0.0 ||
+		    ((init_args->alt_cfg.BOL || init_args->alt_cfg.BUL || init_args->alt_cfg.POL) &&
+		     init_args->alert_value < 0.0)) {
+			printf("INA230(%.2d-%.2x) has invalid alert function config.\n", msg.bus,
+			       msg.target_addr);
+			return SENSOR_INIT_UNSPECIFIED_ERROR;
+		}
+
+		switch (init_args->alt_cfg.value & INA230_ALT_MASK) {
+		case INA230_ALT_SOL_OFFSET:
+		case INA230_ALT_SUL_OFFSET:
+			alt_reg = (uint16_t)(init_args->alert_value / INA230_VSH_VOLTAGE_LSB);
+			break;
+		case INA230_ALT_BOL_OFFSET:
+		case INA230_ALT_BUL_OFFSET:
+			alt_reg = (uint16_t)(init_args->alert_value / INA230_BUS_VOLTAGE_LSB);
+			break;
+		case INA230_ALT_POL_OFFSET:
+			alt_reg = (uint16_t)(init_args->alert_value / init_args->pwr_lsb);
+			break;
+		default:
+			printf("INA230(%.2d-%.2x) has invalid alert function config.\n", msg.bus,
+			       msg.target_addr);
+			return SENSOR_INIT_UNSPECIFIED_ERROR;
+		}
+
+		memset(msg.data, 0, I2C_BUFF_SIZE);
+		msg.data[0] = INA230_ALT_OFFSET;
+		msg.data[1] = (alt_reg >> 8) & 0xFF;
+		msg.data[2] = alt_reg & 0xFF;
+
+		if (i2c_master_write(&msg, I2C_RETRY)) {
+			printf("Failed to set INA230(%.2d-%.2x) alert value.\n", msg.bus,
+			       msg.target_addr);
+			return SENSOR_INIT_UNSPECIFIED_ERROR;
+		}
+
+		memset(msg.data, 0, I2C_BUFF_SIZE);
+		msg.data[0] = INA230_MSK_OFFSET;
+		msg.data[1] = (init_args->alt_cfg.value >> 8) & 0xFF;
+		msg.data[2] = init_args->alt_cfg.value & 0xFF;
+
+		if (i2c_master_write(&msg, I2C_RETRY)) {
+			printf("Failed to set INA230(%.2d-%.2x) mask/enable.\n", msg.bus,
+			       msg.target_addr);
+			return SENSOR_INIT_UNSPECIFIED_ERROR;
+		}
+	}
+
+	init_args->is_init = true;
 
 skip_init:
 	sensor_config[sensor_config_index_map[sensor_num]].read = ina230_read;

--- a/common/dev/include/ina230.h
+++ b/common/dev/include/ina230.h
@@ -1,0 +1,8 @@
+#ifndef __INA230__
+#define __INA230__
+
+#include <stdint.h>
+
+extern uint8_t ina230_reset_alt(uint8_t sensor_num);
+
+#endif

--- a/common/service/sensor/sensor.h
+++ b/common/service/sensor/sensor.h
@@ -37,9 +37,13 @@ enum ADM1278_OFFSET {
 
 enum INA230_OFFSET {
 	INA230_CFG_OFFSET = 0x00,
+	INA230_VSH_VOL_OFFSET = 0x01,
+	INA230_BUS_VOL_OFFSET = 0x02,
 	INA230_PWR_OFFSET = 0x03,
 	INA230_CUR_OFFSET = 0x04,
 	INA230_CAL_OFFSET = 0x05,
+	INA230_MSK_OFFSET = 0x06,
+	INA230_ALT_OFFSET = 0x07,
 };
 
 enum SENSOR_DEV {
@@ -101,20 +105,18 @@ static inline float convert_MBR_to_reading(uint8_t sensor_num, uint8_t val)
 	return (val - round_add(sensor_num, val)) * SDR_M(sensor_num) / SDR_Rexp(sensor_num);
 }
 
-enum {
-	SENSOR_READ_SUCCESS,
-	SENSOR_READ_ACUR_SUCCESS,
-	SENSOR_NOT_FOUND,
-	SENSOR_NOT_ACCESSIBLE,
-	SENSOR_FAIL_TO_ACCESS,
-	SENSOR_INIT_STATUS,
-	SENSOR_UNSPECIFIED_ERROR,
-	SENSOR_POLLING_DISABLE,
-	SENSOR_PRE_READ_ERROR,
-	SENSOR_POST_READ_ERROR,
-	SENSOR_READ_API_UNREGISTER,
-	SENSOR_READ_4BYTE_ACUR_SUCCESS
-};
+enum { SENSOR_READ_SUCCESS,
+       SENSOR_READ_ACUR_SUCCESS,
+       SENSOR_NOT_FOUND,
+       SENSOR_NOT_ACCESSIBLE,
+       SENSOR_FAIL_TO_ACCESS,
+       SENSOR_INIT_STATUS,
+       SENSOR_UNSPECIFIED_ERROR,
+       SENSOR_POLLING_DISABLE,
+       SENSOR_PRE_READ_ERROR,
+       SENSOR_POST_READ_ERROR,
+       SENSOR_READ_API_UNREGISTER,
+       SENSOR_READ_4BYTE_ACUR_SUCCESS };
 
 enum { SENSOR_INIT_SUCCESS, SENSOR_INIT_UNSPECIFIED_ERROR };
 
@@ -226,6 +228,14 @@ typedef struct _pmic_init_arg {
 	uint8_t smbus_addr;
 } pmic_init_arg;
 
+typedef struct _ina233_init_arg_ {
+	bool is_init;
+} ina233_init_arg;
+
+typedef struct _max16550a_init_arg_ {
+	float r_load;
+} max16550a_init_arg;
+
 typedef struct _ina230_init_arg {
 	/* value to set configuration register */
 	union {
@@ -240,24 +250,46 @@ typedef struct _ina230_init_arg {
 		};
 	} config;
 
-	/* Shunt resistor value */
+	/* Shunt resistor value. Unit: Ohm. */
 	double r_shunt;
+
+	/* Alert value.
+	 * The unit is Volt or Watt, depending on the alert function.
+	 */
+	double alert_value;
+
+	/* value to set alert register */
+	union {
+		uint16_t value;
+		struct {
+			uint16_t LEN : 1;
+			uint16_t APOL : 1;
+			uint16_t OVF : 1;
+			uint16_t CVRF : 1;
+			uint16_t AFF : 1;
+			uint16_t reserved : 5;
+			uint16_t CNVR : 1;
+			uint16_t POL : 1; // Lowest priority
+			uint16_t BUL : 1;
+			uint16_t BOL : 1;
+			uint16_t SUL : 1;
+			uint16_t SOL : 1; // Highest priority
+		};
+	} alt_cfg;
 
 	/* Expected maximum current */
 	double i_max;
+
+	/* The current/power value per 1 bit.
+	 * The unit is Amp or Watt, depending on the respective register.
+	 */
+	double cur_lsb;
+	double pwr_lsb;
 
 	/* Initialize function will set following arguments, no need to give value */
 	bool is_init;
 
 } ina230_init_arg;
-
-typedef struct _ina233_init_arg_ {
-	bool is_init;
-} ina233_init_arg;
-
-typedef struct _max16550a_init_arg_ {
-	float r_load;
-} max16550a_init_arg;
 
 extern bool enable_sensor_poll_thread;
 extern uint8_t SDR_NUM;

--- a/meta-facebook/wc-mb/src/platform/plat_hook.c
+++ b/meta-facebook/wc-mb/src/platform/plat_hook.c
@@ -46,16 +46,22 @@ pmic_init_arg pmic_init_args[] = {
 };
 
 ina230_init_arg ina230_init_args[] = {
-	[0] = { .is_init = false,
-		.config =
-			{
-				.MODE = 0b111, // Measure voltage of shunt resistor and bus(default).
-				.VSH_CT = 0b100, // The Vshunt conversion time is 1.1ms(default).
-				.VBUS_CT = 0b100, // The Vbus conversion time is 1.1ms(default).
-				.AVG = 0b000, // Average number is 1(default).
-			},
-		.r_shunt = 0.001,
-		.i_max = 6.0 },
+	[0] = {
+		.is_init = false,
+		.config = {
+			.MODE = 0b111,		// Measure voltage of shunt resistor and bus(default).
+			.VSH_CT = 0b100,	// The Vshunt conversion time is 1.1ms(default).
+			.VBUS_CT = 0b100,	// The Vbus conversion time is 1.1ms(default).
+			.AVG = 0b000,		// Average number is 1(default).
+		},
+		.alt_cfg = {
+			.LEN = 1,			// Alert Latch enabled.
+			.POL = 1,			// Enable the Over-Limit Power alert function.
+		},
+		.r_shunt = 0.01,
+		.alert_value = 18.0,	// Unit: Watt
+		.i_max = 16.384
+		},
 };
 
 /**************************************************************************************************

--- a/meta-facebook/wc-mb/src/platform/plat_sensor_table.c
+++ b/meta-facebook/wc-mb/src/platform/plat_sensor_table.c
@@ -190,6 +190,9 @@ sensor_cfg plat_sensor_config[] = {
 	{ SENSOR_NUM_CUR_IOM_INA, sensor_dev_ina230, I2C_BUS8, INA230_ADDR, INA230_CUR_OFFSET,
 	  stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
 	  &ina230_init_args[0] },
+	{ SENSOR_NUM_VOL_IOM_INA, sensor_dev_ina230, I2C_BUS8, INA230_ADDR, INA230_BUS_VOL_OFFSET,
+	  stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
+	  &ina230_init_args[0] },
 
 	// HSC
 	{ SENSOR_NUM_TEMP_HSC, sensor_dev_mp5990, I2C_BUS5, MPS_MP5990_ADDR,


### PR DESCRIPTION
In this PR, also cherry-picked the INA230 upstream PR, and thus there are some modifications on ina230 c file and the sensor header file.

Tested:
Image build: Passed
```
[279/279] Linking C executable zephyr/WCMB.elf
Memory region         Used Size  Region Size  %age Used
         SRAM_NC:        152 KB       256 KB     59.38%
           FLASH:          0 GB         0 GB
            SRAM:      435480 B       512 KB     83.06%
        IDT_LIST:          0 GB         2 KB      0.00%
```

